### PR TITLE
Use env variables for DB and SFTP credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# PlanillaAquaV
+
+This project requires certain environment variables for database and SFTP connections.
+
+## Required environment variables
+
+- `DB_HOST`
+- `DB_PORT`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASS`
+- `SFTP_HOST`
+- `SFTP_PORT`
+- `SFTP_USER`
+- `SFTP_PASS`
+
+Ensure these variables are set before running the application.

--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ from io import BytesIO
 from base64 import b64encode
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import scoped_session, sessionmaker
+from config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS, DATABASE_URL as CONFIG_DB_URL
 from flask_cors import CORS
 from pytz import timezone
 from datetime import datetime
@@ -42,7 +43,7 @@ app = Flask(__name__)
 socketio = SocketIO(app) 
 
 # Configuración de la base de datos
-DATABASE_URL = 'postgresql+psycopg2://orca:estadoscam.@179.57.170.61:24301/Aquachile'
+DATABASE_URL = CONFIG_DB_URL or f"postgresql+psycopg2://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 engine = create_engine(
     DATABASE_URL,
     pool_size=250,
@@ -287,11 +288,11 @@ def get_db_connection(retries=15, delay=2):
     while attempt < retries:
         try:
             conn = psycopg2.connect(
-                host='179.57.170.61',
-                port='24301',
-                database='Aquachile',
-                user='orca',
-                password='estadoscam.'
+                host=DB_HOST,
+                port=DB_PORT,
+                database=DB_NAME,
+                user=DB_USER,
+                password=DB_PASS
             )
             return conn
         except psycopg2.OperationalError as e:

--- a/config.py
+++ b/config.py
@@ -1,0 +1,18 @@
+import os
+
+DB_HOST = os.environ.get('DB_HOST')
+DB_PORT = os.environ.get('DB_PORT')
+DB_NAME = os.environ.get('DB_NAME')
+DB_USER = os.environ.get('DB_USER')
+DB_PASS = os.environ.get('DB_PASS')
+
+SFTP_HOST = os.environ.get('SFTP_HOST')
+SFTP_PORT = int(os.environ.get('SFTP_PORT', '22')) if os.environ.get('SFTP_PORT') else None
+SFTP_USER = os.environ.get('SFTP_USER')
+SFTP_PASS = os.environ.get('SFTP_PASS')
+
+DATABASE_URL = (
+    f"postgresql+psycopg2://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+    if all([DB_USER, DB_PASS, DB_HOST, DB_PORT, DB_NAME])
+    else None
+)

--- a/final.py
+++ b/final.py
@@ -2,6 +2,17 @@ import os
 import logging
 import paramiko
 import psycopg2
+from config import (
+    DB_HOST,
+    DB_PORT,
+    DB_NAME,
+    DB_USER,
+    DB_PASS,
+    SFTP_HOST,
+    SFTP_PORT,
+    SFTP_USER,
+    SFTP_PASS,
+)
 import base64
 import threading
 from flask import Flask, jsonify, render_template, send_file, Response, url_for, make_response
@@ -71,11 +82,11 @@ def alarm_updater():
             socketio.emit('alarms_update', alarms_data)
 def get_db_connection():
     conn = psycopg2.connect(
-        host='179.57.170.61',
-        port='24301',
-        database='Aquachile',
-        user='orca',
-        password='estadoscam.'
+        host=DB_HOST,
+        port=DB_PORT,
+        database=DB_NAME,
+        user=DB_USER,
+        password=DB_PASS
     )
     return conn
 
@@ -132,7 +143,7 @@ def compare_videos(video1, video2):
     return 0
 
 def get_video_urls():
-    sftp = create_sftp_client('179.57.170.61', 2222, 'sql', '753524')
+    sftp = create_sftp_client(SFTP_HOST, SFTP_PORT, SFTP_USER, SFTP_PASS)
     videos = sftp.listdir('/home/videos')
     sftp.close()
     # Filtrar y ordenar los videos que siguen el formato correcto
@@ -149,7 +160,7 @@ def get_video_urls():
     return video_urls
 
 def get_latest_video():
-    sftp = create_sftp_client('179.57.170.61', 2222, 'sql', '753524')
+    sftp = create_sftp_client(SFTP_HOST, SFTP_PORT, SFTP_USER, SFTP_PASS)
     videos = sftp.listdir('/home/videos')
     sftp.close()
     latest_video = None
@@ -240,7 +251,7 @@ def video(filename):
     decoded_filename = unquote(filename)
     local_file_path = os.path.join('/home/estadoscam/mi_flask_env/proyecto2/videos', decoded_filename)
     if not os.path.isfile(local_file_path):
-        sftp = create_sftp_client('179.57.170.61', 2222, 'sql', '753524')
+        sftp = create_sftp_client(SFTP_HOST, SFTP_PORT, SFTP_USER, SFTP_PASS)
         try:
             sftp.get(f'/home/videos/{filename}', local_file_path)
         except Exception as e:

--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,7 @@ import ujson as json  # Usar ujson para serialización más rápida
 import redis
 import psycopg2
 import psycopg2.pool
+from config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS
 import pytz
 from celery import Celery
 from datetime import datetime
@@ -25,11 +26,11 @@ app.conf.update(
 # Crear un pool de conexiones para la base de datos
 db_pool = psycopg2.pool.SimpleConnectionPool(
     1, 20,  # Mínimo 1 y máximo 20 conexiones en el pool
-    host='179.57.170.61',
-    port='24301',
-    database='Aquachile',
-    user='orca',
-    password='estadoscam.'
+    host=DB_HOST,
+    port=DB_PORT,
+    database=DB_NAME,
+    user=DB_USER,
+    password=DB_PASS
 )
 
 # Función para obtener una conexión desde el pool de conexiones

--- a/voz_tasks.py
+++ b/voz_tasks.py
@@ -3,6 +3,7 @@ import pytz
 from datetime import datetime, timedelta, time as datetime_time
 from gevent import sleep
 import psycopg2
+from config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS
 
 # Configuración de Celery
 app = Celery('voz_tasks', broker='redis://10.11.10.26:6379/0', backend='redis://10.11.10.26:6379/0')
@@ -21,11 +22,11 @@ def get_db_connection(retries=15, delay=2):
     while attempt < retries:
         try:
             conn = psycopg2.connect(
-                host='179.57.170.61',
-                port='24301',
-                database='Aquachile',
-                user='orca',
-                password='estadoscam.'
+                host=DB_HOST,
+                port=DB_PORT,
+                database=DB_NAME,
+                user=DB_USER,
+                password=DB_PASS
             )
             return conn
         except psycopg2.OperationalError as e:


### PR DESCRIPTION
## Summary
- add `config.py` to read DB and SFTP settings from environment
- update database connection helpers in `app.py`, `tasks.py`, `voz_tasks.py`, and `final.py`
- document needed environment variables

## Testing
- `python -m py_compile app.py tasks.py voz_tasks.py final.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6879498d0450832dbd2401d54452e1df