### PR TITLE
Fix timing logic for alarm processing

### DIFF
--- a/app_fixed.py
+++ b/app_fixed.py
@@ -270,7 +270,8 @@ def get_alarms_data(start_time=None, end_time=None):
                 start_time = (end_time - timedelta(days=1)).replace(hour=18, minute=30, second=0, microsecond=0)
 
         cursor.execute("""
-            SELECT id, centro, duracion, en_modulo, estado_verificacion, observacion, timestamp
+            SELECT id, centro, duracion, en_modulo, estado_verificacion, observacion, timestamp,
+                   observation_timestamp, observacion_texto, accion, gestionado_time, gestionado_dentro_de_tiempo
             FROM alarmas
             WHERE timestamp BETWEEN %s AND %s
             ORDER BY timestamp DESC
@@ -282,22 +283,32 @@ def get_alarms_data(start_time=None, end_time=None):
         
         alarms_data = []
         for alarm in alarms:
+            gestionado = bool(alarm[5] and str(alarm[5]).strip())
+            gestionado_time = alarm[10]
+            gestionado_dentro = alarm[11]
+            if alarm[7] and gestionado_time is None:
+                gestionado_time = alarm[7]
+                diff_minutes = (gestionado_time - alarm[6]).total_seconds() / 60.0
+                gestionado_dentro = diff_minutes <= 10
+                cursor2 = conn.cursor()
+                cursor2.execute("UPDATE alarmas SET gestionado_time = %s, gestionado_dentro_de_tiempo = %s WHERE id = %s", (gestionado_time, gestionado_dentro, alarm[0]))
+                conn.commit()
+                cursor2.close()
             alarms_data.append({
                 'id': alarm[0],
                 'fecha': alarm[6].strftime('%Y-%m-%d'),
                 'hora': alarm[6].strftime('%H:%M:%S'),
                 'centro': alarm[1],
                 'duracion': format_duration(alarm[2]),
-                'en_modulo': "Módulo" if alarm[3] else "Fuera del Módulo",
+                'en_modulo': 'Módulo' if alarm[3] else 'Fuera del Módulo',
                 'estado_verificacion': alarm[4],
-                'observacion': alarm[5] or "",
-                'gestionado': bool(alarm[5] and alarm[5].strip()),
-                'gestionado_time': None,
-                'gestionado_dentro_de_tiempo': None,
-                'observacion_texto': alarm[5] or "",
-                'accion': ""
+                'observacion': alarm[5] or '',
+                'gestionado': gestionado,
+                'gestionado_time': gestionado_time.strftime('%H:%M') if gestionado_time else None,
+                'gestionado_dentro_de_tiempo': gestionado_dentro,
+                'observacion_texto': alarm[8] or '',
+                'accion': alarm[9] or ''
             })
-        
         return alarms_data
         
     except Exception as e:
@@ -499,28 +510,49 @@ def format_duration(seconds):
         return f"{seconds} segundo{'s' if seconds != 1 else ''}"
 
 def update_observation_in_db_sync(alarm_id, observation, observation_timestamp=None, action=None):
-    """Actualizar observación de alarma de forma síncrona"""
+    """Actualizar observación de alarma y calcular si fue gestionada a tiempo."""
     try:
+        chile_tz = pytz.timezone('America/Santiago')
+        if observation_timestamp is None:
+            observation_timestamp = datetime.now(chile_tz)
+        elif observation_timestamp.tzinfo is None:
+            observation_timestamp = chile_tz.localize(observation_timestamp)
+        else:
+            observation_timestamp = observation_timestamp.astimezone(chile_tz)
         conn = get_db_connection()
         cursor = conn.cursor()
-        
+        cursor.execute("SELECT timestamp FROM alarmas WHERE id = %s", (alarm_id,))
+        result = cursor.fetchone()
+        detection_time = result[0] if result else None
+        gestionado_dentro = None
+        if detection_time:
+            diff_minutes = (observation_timestamp - detection_time).total_seconds() / 60.0
+            gestionado_dentro = diff_minutes <= 10
         cursor.execute("""
             UPDATE alarmas
-            SET observacion = %s
+            SET observacion = %s,
+                observation_timestamp = %s,
+                observacion_texto = %s,
+                accion = %s,
+                gestionado_time = %s,
+                gestionado_dentro_de_tiempo = %s
             WHERE id = %s
-        """, (observation, alarm_id))
-        
+        """, (
+            observation,
+            observation_timestamp,
+            observation,
+            action,
+            observation_timestamp,
+            gestionado_dentro,
+            alarm_id,
+        ))
         conn.commit()
         cursor.close()
         conn.close()
-        
         logger.info(f"Observación actualizada para alarma {alarm_id}")
-        
     except Exception as e:
         logger.error(f"Error actualizando observación: {e}")
         raise
-
-
 def voz_data_updater():
     """Tarea en segundo plano para enviar datos de voz"""
     chile_tz = pytz.timezone('America/Santiago')

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -228,6 +228,11 @@ tbody tr:hover {
     border-radius: 5px; /* Redondea los bordes con un radio de 5px */
     padding: 10px; /* Añade un poco de espacio dentro del borde para que el contenido no esté pegado al borde */
 }
+
+/* Estilo para filas no gestionadas */
+.no-gestionado-row {
+    background-color: rgba(255, 0, 0, 0.2); /* Tono rojizo transparente */
+}
 .time-icon {
     width: 28px; /* Puedes ajustar el tamaño según tus necesidades */
     height: 28px;

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -813,6 +813,8 @@ function updateAlarmsTable(filteredData) {
 
         if (alarm.gestionado) {
             row.classList.add('gestionado-row');
+        } else {
+            row.classList.add('no-gestionado-row');
         }
 
         if (selectedAlarmIds.has(alarm.id)) {
@@ -858,11 +860,13 @@ function updateAlarmRow(alarmId, newObservation, observationTimestamp) {
 
             if (newObservation.trim() !== "") {
                 centroCell.innerHTML = `${centroText} <span class='gestionado'>(Gestionado)</span><span class='checkmark'>&#10003;</span> <span class='gestionado-time'>${localTime}</span>`;
+                row.classList.remove('no-gestionado-row');
                 row.classList.add('gestionado-row');
                 row.setAttribute('data-gestionado-time', localTime);
             } else {
                 const existingTime = row.getAttribute('data-gestionado-time');
                 centroCell.innerHTML = `${centroText} <span class='gestionado'>(Gestionado)</span><span class='checkmark'>&#10003;</span> <span class='gestionado-time'>${existingTime || localTime}</span>`;
+                row.classList.remove('no-gestionado-row');
                 row.classList.add('gestionado-row');
                 row.setAttribute('data-gestionado-time', existingTime || localTime);
             }


### PR DESCRIPTION
## Summary
- calculate time difference when updating alarm observations
- expose `update_observation_in_db` Celery task and route it
- style unprocessed alarm rows with reddish tone
- show row state in table update logic
- apply timing fix to `app_fixed`

## Testing
- `python3 -m py_compile app_fixed.py app.py tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68797afa7d78832d80b7e527ac2a818a