### PR TITLE
Fix observation row disappearance

### DIFF
--- a/app_fixed.py
+++ b/app_fixed.py
@@ -270,7 +270,8 @@ def get_alarms_data(start_time=None, end_time=None):
                 start_time = (end_time - timedelta(days=1)).replace(hour=18, minute=30, second=0, microsecond=0)
 
         cursor.execute("""
-            SELECT id, centro, duracion, en_modulo, estado_verificacion, observacion, timestamp
+            SELECT id, centro, duracion, en_modulo, estado_verificacion, observacion, timestamp,
+                   observation_timestamp, observacion_texto, accion, gestionado_time, gestionado_dentro_de_tiempo
             FROM alarmas
             WHERE timestamp BETWEEN %s AND %s
             ORDER BY timestamp DESC
@@ -282,22 +283,32 @@ def get_alarms_data(start_time=None, end_time=None):
         
         alarms_data = []
         for alarm in alarms:
+            gestionado = bool(alarm[5] and str(alarm[5]).strip())
+            gestionado_time = alarm[10]
+            gestionado_dentro = alarm[11]
+            if alarm[7] and gestionado_time is None:
+                gestionado_time = alarm[7]
+                diff_minutes = (gestionado_time - alarm[6]).total_seconds() / 60.0
+                gestionado_dentro = diff_minutes <= 10
+                cursor2 = conn.cursor()
+                cursor2.execute("UPDATE alarmas SET gestionado_time = %s, gestionado_dentro_de_tiempo = %s WHERE id = %s", (gestionado_time, gestionado_dentro, alarm[0]))
+                conn.commit()
+                cursor2.close()
             alarms_data.append({
                 'id': alarm[0],
                 'fecha': alarm[6].strftime('%Y-%m-%d'),
                 'hora': alarm[6].strftime('%H:%M:%S'),
                 'centro': alarm[1],
                 'duracion': format_duration(alarm[2]),
-                'en_modulo': "Módulo" if alarm[3] else "Fuera del Módulo",
+                'en_modulo': 'Módulo' if alarm[3] else 'Fuera del Módulo',
                 'estado_verificacion': alarm[4],
-                'observacion': alarm[5] or "",
-                'gestionado': bool(alarm[5] and alarm[5].strip()),
-                'gestionado_time': None,
-                'gestionado_dentro_de_tiempo': None,
-                'observacion_texto': alarm[5] or "",
-                'accion': ""
+                'observacion': alarm[5] or '',
+                'gestionado': gestionado,
+                'gestionado_time': gestionado_time.strftime('%H:%M') if gestionado_time else None,
+                'gestionado_dentro_de_tiempo': gestionado_dentro,
+                'observacion_texto': alarm[8] or '',
+                'accion': alarm[9] or ''
             })
-        
         return alarms_data
         
     except Exception as e:
@@ -499,28 +510,55 @@ def format_duration(seconds):
         return f"{seconds} segundo{'s' if seconds != 1 else ''}"
 
 def update_observation_in_db_sync(alarm_id, observation, observation_timestamp=None, action=None):
-    """Actualizar observación de alarma de forma síncrona"""
+    """Actualizar observación de alarma y calcular si fue gestionada a tiempo."""
     try:
+        chile_tz = pytz.timezone('America/Santiago')
+        if observation_timestamp is None:
+            observation_timestamp = datetime.now(chile_tz)
+        elif observation_timestamp.tzinfo is None:
+            observation_timestamp = chile_tz.localize(observation_timestamp)
+        else:
+            observation_timestamp = observation_timestamp.astimezone(chile_tz)
         conn = get_db_connection()
         cursor = conn.cursor()
-        
+        cursor.execute("SELECT timestamp FROM alarmas WHERE id = %s", (alarm_id,))
+        result = cursor.fetchone()
+        detection_time = result[0] if result else None
+        gestionado_dentro = None
+        if detection_time:
+            if detection_time.tzinfo is None:
+                detection_time = chile_tz.localize(detection_time)
+            else:
+                detection_time = detection_time.astimezone(chile_tz)
+
+            diff_minutes = (observation_timestamp - detection_time).total_seconds() / 60.0
+            gestionado_dentro = diff_minutes <= 10
         cursor.execute("""
             UPDATE alarmas
-            SET observacion = %s
+            SET observacion = %s,
+                observation_timestamp = %s,
+                observacion_texto = %s,
+                accion = %s,
+                gestionado_time = %s,
+                gestionado_dentro_de_tiempo = %s
             WHERE id = %s
-        """, (observation, alarm_id))
-        
+        """, (
+            observation,
+            observation_timestamp,
+            observation,
+            action,
+            observation_timestamp,
+            gestionado_dentro,
+            alarm_id,
+        ))
         conn.commit()
         cursor.close()
         conn.close()
-        
         logger.info(f"Observación actualizada para alarma {alarm_id}")
-        
+        return gestionado_dentro
     except Exception as e:
         logger.error(f"Error actualizando observación: {e}")
         raise
-
-
 def voz_data_updater():
     """Tarea en segundo plano para enviar datos de voz"""
     chile_tz = pytz.timezone('America/Santiago')
@@ -632,14 +670,23 @@ def handle_update_observation(data):
             observation_timestamp = isoparse(observation_timestamp)
         
         # Actualizar observación de forma síncrona
-        update_observation_in_db_sync(alarm_id, observation, observation_timestamp, action)
-        
-        emit('observation_updated', {
-            'id': alarm_id,
-            'observation': observation,
-            'observation_timestamp': observation_timestamp.isoformat() if observation_timestamp else None,
-            'action': action
-        }, broadcast=True)
+        gestionado_dentro = update_observation_in_db_sync(
+            alarm_id, observation, observation_timestamp, action
+        )
+
+        emit(
+            'observation_updated',
+            {
+                'id': alarm_id,
+                'observation': observation,
+                'observation_timestamp': observation_timestamp.isoformat()
+                if observation_timestamp
+                else None,
+                'action': action,
+                'gestionado_dentro_de_tiempo': gestionado_dentro,
+            },
+            broadcast=True,
+        )
         
     except Exception as e:
         logger.error(f"Error actualizando observación: {e}")

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -228,6 +228,11 @@ tbody tr:hover {
     border-radius: 5px; /* Redondea los bordes con un radio de 5px */
     padding: 10px; /* Añade un poco de espacio dentro del borde para que el contenido no esté pegado al borde */
 }
+
+/* Estilo para filas no gestionadas */
+.no-gestionado-row {
+    background-color: rgba(255, 0, 0, 0.2); /* Tono rojizo transparente */
+}
 .time-icon {
     width: 28px; /* Puedes ajustar el tamaño según tus necesidades */
     height: 28px;

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -69,6 +69,18 @@ document.getElementById('logo').addEventListener('click', function() {
             console.log("Datos de voz recibidos:", data);
             handleVozDataUpdate(data);
         });
+
+        socket.on('observation_updated', function(data) {
+            console.log('Observación actualizada:', data);
+            const alarm = alarmsData.find(a => String(a.id) === String(data.id));
+            if (alarm) {
+                alarm.observacion = data.observation;
+                alarm.gestionado_time = data.observation_timestamp;
+                alarm.gestionado = data.observation.trim() !== '';
+                alarm.gestionado_dentro_de_tiempo = data.gestionado_dentro_de_tiempo;
+            }
+            updateAlarmRow(data.id, data.observation, data.observation_timestamp);
+        });
     }
 
         
@@ -813,6 +825,8 @@ function updateAlarmsTable(filteredData) {
 
         if (alarm.gestionado) {
             row.classList.add('gestionado-row');
+        } else {
+            row.classList.add('no-gestionado-row');
         }
 
         if (selectedAlarmIds.has(alarm.id)) {
@@ -858,11 +872,13 @@ function updateAlarmRow(alarmId, newObservation, observationTimestamp) {
 
             if (newObservation.trim() !== "") {
                 centroCell.innerHTML = `${centroText} <span class='gestionado'>(Gestionado)</span><span class='checkmark'>&#10003;</span> <span class='gestionado-time'>${localTime}</span>`;
+                row.classList.remove('no-gestionado-row');
                 row.classList.add('gestionado-row');
                 row.setAttribute('data-gestionado-time', localTime);
             } else {
                 const existingTime = row.getAttribute('data-gestionado-time');
                 centroCell.innerHTML = `${centroText} <span class='gestionado'>(Gestionado)</span><span class='checkmark'>&#10003;</span> <span class='gestionado-time'>${existingTime || localTime}</span>`;
+                row.classList.remove('no-gestionado-row');
                 row.classList.add('gestionado-row');
                 row.setAttribute('data-gestionado-time', existingTime || localTime);
             }

--- a/tasks.py
+++ b/tasks.py
@@ -5,6 +5,7 @@ Tareas asíncronas con Celery
 import logging
 import time
 from datetime import datetime
+import pytz
 from celery import Celery
 from config import Config
 from database import db_manager
@@ -28,6 +29,7 @@ def setup_celery(app):
         enable_utc=True,
         task_routes={
             'tasks.update_observation_task': {'queue': 'observations'},
+            'tasks.update_observation_in_db': {'queue': 'observations'},
             'tasks.cleanup_old_data': {'queue': 'maintenance'},
         },
         beat_schedule={
@@ -81,6 +83,69 @@ def update_observation_task(self, alarm_id, observation, observation_timestamp, 
             'alarm_id': alarm_id,
             'error': str(e)
         }
+
+@celery.task(bind=True)
+def update_observation_in_db(self, alarm_id, observation, observation_timestamp, action):
+    """Actualizar observación y calcular si se gestionó dentro de los 10 minutos."""
+    start_time = time.time()
+    try:
+        chile_tz = pytz.timezone('America/Santiago')
+
+        if isinstance(observation_timestamp, str):
+            observation_timestamp = datetime.fromisoformat(observation_timestamp)
+
+        if observation_timestamp.tzinfo is None:
+            observation_timestamp = chile_tz.localize(observation_timestamp)
+        else:
+            observation_timestamp = observation_timestamp.astimezone(chile_tz)
+
+        with db_manager.get_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT timestamp FROM alarmas WHERE id = %s", (alarm_id,))
+                result = cursor.fetchone()
+                detection_time = result[0] if result else None
+
+                gestionado_dentro = None
+                if detection_time:
+                    if detection_time.tzinfo is None:
+                        detection_time = chile_tz.localize(detection_time)
+                    else:
+                        detection_time = detection_time.astimezone(chile_tz)
+
+                    diff = (observation_timestamp - detection_time).total_seconds() / 60.0
+                    gestionado_dentro = diff <= 10
+
+                cursor.execute(
+                    """
+                    UPDATE alarmas
+                    SET observacion = %s,
+                        observation_timestamp = %s,
+                        observacion_texto = %s,
+                        accion = %s,
+                        gestionado_time = %s,
+                        gestionado_dentro_de_tiempo = %s
+                    WHERE id = %s
+                    """,
+                    (
+                        observation,
+                        observation_timestamp,
+                        observation,
+                        action,
+                        observation_timestamp,
+                        gestionado_dentro,
+                        alarm_id,
+                    ),
+                )
+                conn.commit()
+                return gestionado_dentro
+    except Exception as e:
+        logger.error(f"Error actualizando observación: {e}")
+        raise
+    finally:
+        total_time = time.time() - start_time
+        logger.warning(
+            f"Tiempo total para update_observation_in_db: {total_time:.4f} segundos"
+        )
 
 @celery.task
 def voz_data_updater_task():


### PR DESCRIPTION
## Summary
- keep timezone consistent when computing observation delays
- return timing flag from observation update
- broadcast `gestionado_dentro_de_tiempo` to clients
- update client-side dataset when an observation is updated

## Testing
- `python3 -m py_compile app_fixed.py app.py tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_68797afa7d78832d80b7e527ac2a818a