### PR TITLE
Add strike-through style for unmanaged centers

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -231,7 +231,7 @@ tbody tr:hover {
 
 /* Estilo para filas no gestionadas */
 .no-gestionado-row {
-    background-color: rgba(255, 0, 0, 0.2); /* Tono rojizo transparente */
+    /* Sin color de fondo para las filas no gestionadas */
 }
 .time-icon {
     width: 28px; /* Puedes ajustar el tamaño según tus necesidades */
@@ -281,6 +281,12 @@ tbody tr:hover {
     color: #00FF00; /* Verde eléctrico */
     font-size: 12px; /* Tamaño del checkmark */
     margin-left: 5px; /* Espacio a la izquierda del texto "(Gestionado)" */
+}
+
+/* Texto tachado para centros no gestionados */
+.centro-no-gestionado {
+    color: red;
+    text-decoration: line-through;
 }
 
 /* Estilos para la barra de progreso */

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -812,10 +812,14 @@ function updateAlarmsTable(filteredData) {
 
         const observationText = localObservations.hasOwnProperty(alarm.id) ? localObservations[alarm.id] : alarm.observacion;
 
+        const centroHtml = alarm.gestionado
+            ? `${alarm.centro} <span class='gestionado'>(Gestionado)</span><span class='checkmark'>&#10003;</span> ${alarm.gestionado_time || ''}`
+            : `<span class='centro-no-gestionado'>${alarm.centro}</span>`;
+
         row.innerHTML = `
             <td>${alarm.fecha}</td>
             <td>${alarm.hora} ${timeIcon}</td>
-            <td>${alarm.centro} ${alarm.gestionado ? "<span class='gestionado'>(Gestionado)</span><span class='checkmark'>&#10003;</span> " + (alarm.gestionado_time || '') : ""}</td>
+            <td>${centroHtml}</td>
             <td>${alarm.duracion}</td>
             <td>${alarm.en_modulo}</td>
             <td>${getIconForVerificationState(alarm.estado_verificacion)} ${alarm.estado_verificacion}
@@ -835,6 +839,7 @@ function updateAlarmsTable(filteredData) {
 
         row.setAttribute('data-alarm-id', alarm.id);
         row.setAttribute('data-gestionado-time', alarm.gestionado_time); // Almacena la hora gestionada en el atributo de datos
+        row.setAttribute('data-center-name', alarm.centro); // Guarda el nombre del centro para futuras actualizaciones
         // Guardar el timestamp completo de detección para cálculo posterior
         row.setAttribute('data-detection-timestamp', `${alarm.fecha}T${alarm.hora}`);
 
@@ -872,21 +877,20 @@ function updateAlarmRow(alarmId, newObservation, observationTimestamp) {
             row.cells[6].textContent = newObservation;
 
             // Actualizar la celda "centro" para reflejar que la alarma está gestionada o no gestionada
-            const centroCell = row.cells[2];
-            const centroText = centroCell.innerText.split(" (Gestionado)")[0];
+        const centroCell = row.cells[2];
+        const centroText = row.getAttribute('data-center-name');
 
-            if (newObservation.trim() !== "") {
-                centroCell.innerHTML = `${centroText} <span class='gestionado'>(Gestionado)</span><span class='checkmark'>&#10003;</span> <span class='gestionado-time'>${localTime}</span>`;
-                row.classList.remove('no-gestionado-row');
-                row.classList.add('gestionado-row');
-                row.setAttribute('data-gestionado-time', localTime);
-            } else {
-                const existingTime = row.getAttribute('data-gestionado-time');
-                centroCell.innerHTML = `${centroText} <span class='gestionado'>(Gestionado)</span><span class='checkmark'>&#10003;</span> <span class='gestionado-time'>${existingTime || localTime}</span>`;
-                row.classList.remove('no-gestionado-row');
-                row.classList.add('gestionado-row');
-                row.setAttribute('data-gestionado-time', existingTime || localTime);
-            }
+        if (newObservation.trim() !== '') {
+            centroCell.innerHTML = `${centroText} <span class='gestionado'>(Gestionado)</span><span class='checkmark'>&#10003;</span> <span class='gestionado-time'>${localTime}</span>`;
+            row.classList.remove('no-gestionado-row');
+            row.classList.add('gestionado-row');
+            row.setAttribute('data-gestionado-time', localTime);
+        } else {
+            centroCell.innerHTML = `<span class='centro-no-gestionado'>${centroText}</span>`;
+            row.classList.remove('gestionado-row');
+            row.classList.add('no-gestionado-row');
+            row.removeAttribute('data-gestionado-time');
+        }
         }
     });
 }


### PR DESCRIPTION
## Summary
- remove red highlight from unmanaged rows
- show red strike-through text on center name when not managed

## Testing
- `./run.sh test` *(fails: `.env.example` missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c1722ca0832d9b2fff5a3fd42784